### PR TITLE
Update KiCad to correct URL

### DIFF
--- a/modules/KiCad.php
+++ b/modules/KiCad.php
@@ -2,10 +2,10 @@
 
 class KiCad extends PatchBase {
 	function __construct() {
-		parent::__construct('KiCad Developers', 'KiCad', 'https://kicad-pcb.org/download/');
+		parent::__construct('KiCad Developers', 'KiCad', 'https://kicad.org/download/');
 	}
 	function check() : bool {
-		if ($this->fetch('https://kicad-pcb.org/download/source/'))
+		if ($this->fetch('https://kicad.org/download/source/'))
 			return $this->parse('/<p>Current Version: <strong>([\d\.]+)<\/strong><\/p>/');
 		return false;
 	}


### PR DESCRIPTION
old domain is no longer valid!

https://forum.kicad.info/t/warning-avoid-all-links-to-kicad-pcb-org-use-kicad-org/31521/72
https://www.kicad.org/blog/2021/10/Avoid-links-to-former-kicad-domain